### PR TITLE
Log an exception if it happened not just in a step but in a test method as well

### DIFF
--- a/src/main/java/com/github/invictum/reportportal/Utils.java
+++ b/src/main/java/com/github/invictum/reportportal/Utils.java
@@ -1,5 +1,6 @@
 package com.github.invictum.reportportal;
 
+import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestResult;
 import net.thucydides.core.model.TestStep;
 
@@ -27,6 +28,17 @@ public class Utils {
      */
     public static Date stepEndDate(TestStep step) {
         ZonedDateTime endTimeZoned = step.getStartTime().plus(Duration.ofMillis(step.getDuration()));
+        return Date.from(endTimeZoned.toInstant());
+    }
+
+    /**
+     * Calculates test's end time.
+     *
+     * @param test to calculate time on
+     * @return test end time in {@link Date} format
+     */
+    public static Date testEndDate(TestOutcome test) {
+        ZonedDateTime endTimeZoned = test.getStartTime().plus(Duration.ofMillis(test.getDuration()));
         return Date.from(endTimeZoned.toInstant());
     }
 

--- a/src/main/java/com/github/invictum/reportportal/log/unit/Error.java
+++ b/src/main/java/com/github/invictum/reportportal/log/unit/Error.java
@@ -2,6 +2,8 @@ package com.github.invictum.reportportal.log.unit;
 
 import com.epam.ta.reportportal.ws.model.log.SaveLogRQ;
 import com.github.invictum.reportportal.Utils;
+
+import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestStep;
 
 import java.io.PrintWriter;
@@ -12,17 +14,26 @@ import java.util.function.Function;
 
 public class Error {
 
-    private static final Function<TestStep, String> DEFAULT_FORMATTER = step -> {
+    private static final Function<TestStep, String> STEP_FORMATTER = step -> {
         Throwable cause = step.getException().getOriginalCause();
+        return stringifyStackTrace(cause);
+    };
+
+    private static final Function<TestOutcome, String> TEST_FORMATTER = testOutcome -> {
+        Throwable cause = testOutcome.getTestFailureCause().toException();
+        return stringifyStackTrace(cause);
+    };
+
+    private static String stringifyStackTrace(Throwable cause){
         StringWriter writer = new StringWriter();
         cause.printStackTrace(new PrintWriter(writer));
         return writer.toString();
-    };
+    }
 
     /**
      * Logs error using preconfigured {@link Function} representation of formatter
      */
-    public static Function<TestStep, Collection<SaveLogRQ>> configuredError(Function<TestStep, String> errorFormatter) {
+    public static Function<TestStep, Collection<SaveLogRQ>> configuredStepError(Function<TestStep, String> errorFormatter) {
         return step -> {
             if (step.getException() != null) {
                 SaveLogRQ log = new SaveLogRQ();
@@ -36,9 +47,32 @@ public class Error {
     }
 
     /**
-     * Logs error using default error formatter - print error with full stack trace
+     * Logs error using preconfigured {@link Function} representation of formatter
+     */
+    public static Function<TestOutcome, Collection<SaveLogRQ>> configuredTestError(Function<TestOutcome, String> errorFormatter) {
+        return testOutcome -> {
+            if (!testOutcome.getFailingStep().isPresent() && testOutcome.getTestFailureCause() != null) {
+                SaveLogRQ log = new SaveLogRQ();
+                log.setMessage(errorFormatter.apply(testOutcome));
+                log.setLevel(Utils.logLevel(testOutcome.getResult()));
+                log.setLogTime(Utils.testEndDate(testOutcome));
+                return Collections.singleton(log);
+            }
+            return Collections.emptySet();
+        };
+    }
+
+    /**
+     * Logs error in step using default error formatter - print error with full stack trace
      */
     public static Function<TestStep, Collection<SaveLogRQ>> basic() {
-        return configuredError(DEFAULT_FORMATTER);
+        return configuredStepError(STEP_FORMATTER);
+    }
+
+    /**
+     * Logs error in test (outside of a step) using default error formatter - print error with full stack trace
+     */
+    public static Function<TestOutcome, Collection<SaveLogRQ>> errorInTest() {
+        return configuredTestError(TEST_FORMATTER);
     }
 }


### PR DESCRIPTION
In cases like this 
`@Test`
`public void someTest(){`
`someStep.doSomething();`
`assertThat(%whatever%).isEqualTo(%whatever_else%)`
`}`
if assertion in the last line fails, it doesn't appear in report portal.
This PR is aimed to fix it.