### PR TITLE
Fix launch finish before full report are submited

### DIFF
--- a/src/main/java/com/github/invictum/reportportal/injector/ReportLaunchProvider.java
+++ b/src/main/java/com/github/invictum/reportportal/injector/ReportLaunchProvider.java
@@ -37,7 +37,7 @@ public class ReportLaunchProvider implements Provider<Launch> {
             // Finish launch
             FinishExecutionRQ finishExecutionRQ = new FinishExecutionRQ();
             finishExecutionRQ.setEndTime(Calendar.getInstance().getTime());
-            reportPortal.getClient().finishLaunch(uuid, finishExecutionRQ).blockingGet();
+            launch.finish(finishExecutionRQ);
             // Activate merge if parameters are passed
             if (DIR != null && MODULES_COUNT > 1) {
                 fileStorage = new FileStorage(DIR);


### PR DESCRIPTION
Sometimes library could finish launch before all test items a reported. Example you could find on screen:
![Screenshot from 2020-07-29 17-10-05](https://user-images.githubusercontent.com/5778094/88810821-8561ec00-d1be-11ea-8f24-bc205d0b382e.png)
This is the fix of this problem.

The method "finish" do "Finishes launch in ReportPortal. Blocks until all items are reported correctly" according to report portal client documentations.