### PR TITLE
Add support for Report Portal 5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.epam.reportportal</groupId>
             <artifactId>commons-model</artifactId>
-            <version>5.2.2</version>
+            <version>5.3.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
At this moment seems that client don't work properly with Report Portal version 5.3. This PR should fix this problem. Could you release client version 1.5.3? Thanks.