### PR TITLE
Remove RESETED status.

### DIFF
--- a/src/main/java/com/github/invictum/reportportal/Status.java
+++ b/src/main/java/com/github/invictum/reportportal/Status.java
@@ -14,7 +14,7 @@ public enum Status {
     PASSED(LogLevel.INFO, TestResult.SUCCESS),
     FAILED(LogLevel.ERROR, TestResult.ERROR, TestResult.FAILURE),
     SKIPPED(LogLevel.DEBUG, TestResult.IGNORED, TestResult.SKIPPED, TestResult.PENDING),
-    RESETED(LogLevel.WARN, TestResult.COMPROMISED),
+    STOPPED(LogLevel.WARN, TestResult.COMPROMISED),
     CANCELLED(LogLevel.FATAL, TestResult.UNDEFINED);
 
     private List<TestResult> map;
@@ -30,6 +30,6 @@ public enum Status {
     }
 
     public static Status mapTo(TestResult result) {
-        return Arrays.stream(values()).filter(item -> item.map.contains(result)).findFirst().orElse(Status.RESETED);
+        return Arrays.stream(values()).filter(item -> item.map.contains(result)).findFirst().orElse(Status.STOPPED);
     }
 }


### PR DESCRIPTION
Report portal team changed allowed statuses in version 5.x so at this moment they don't have states RESETED.
This fix should solve problem like:
```
21:22:45  com.epam.reportportal.exception.ReportPortalException: Report Portal returned error
21:22:45  Status code: 400
21:22:45  Status message: Bad Request
21:22:45  Error Message: Incorrect Request. [Value is not allowed for field 'status'.] 
21:22:45  Error Type: INCORRECT_REQUEST
```