### PR TITLE
Update BddDataDriven.java

### DIFF
--- a/src/main/java/com/github/invictum/reportportal/recorder/BddDataDriven.java
+++ b/src/main/java/com/github/invictum/reportportal/recorder/BddDataDriven.java
@@ -9,6 +9,8 @@ import io.reactivex.Maybe;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestStep;
 
+import java.util.Arrays;
+
 /**
  * Recorder aware of parameterized BDD style test specific handling
  */
@@ -38,7 +40,7 @@ public class BddDataDriven extends TestRecorder {
                 .build();
         Maybe<String> testId = launch.startTestItem(id, startScenario);
         // Steps
-        proceedSteps(testId, out.getTestSteps());
+        proceedSteps(testId, Arrays.asList(test));
         // Stop test
         FinishTestItemRQ finishScenario = new FinishEventBuilder()
                 .withStatus(Status.mapTo(test.getResult()))


### PR DESCRIPTION
Fix CHILD_START_TIME_EARLIER_THAN_PARENT error 

See https://github.com/Invictum/serenity-reportportal-integration/issues/131