### PR TITLE
Bintray was removed 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,17 +39,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-epam-reportportal</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/epam/reportportal</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>net.serenity-bdd</groupId>

--- a/src/main/java/com/github/invictum/reportportal/Status.java
+++ b/src/main/java/com/github/invictum/reportportal/Status.java
@@ -13,12 +13,11 @@ public enum Status {
 
     PASSED(LogLevel.INFO, TestResult.SUCCESS),
     FAILED(LogLevel.ERROR, TestResult.ERROR, TestResult.FAILURE),
-    SKIPPED(LogLevel.DEBUG, TestResult.IGNORED, TestResult.SKIPPED, TestResult.PENDING),
-    STOPPED(LogLevel.WARN, TestResult.COMPROMISED),
-    CANCELLED(LogLevel.FATAL, TestResult.UNDEFINED);
+    SKIPPED(LogLevel.DEBUG, TestResult.IGNORED, TestResult.SKIPPED, TestResult.PENDING, TestResult.COMPROMISED),
+    CANCELLED(LogLevel.FATAL, TestResult.UNDEFINED, TestResult.UNSUCCESSFUL);
 
-    private List<TestResult> map;
-    private LogLevel level;
+    private final List<TestResult> map;
+    private final LogLevel level;
 
     Status(LogLevel level, TestResult... statuses) {
         map = Arrays.asList(statuses);
@@ -30,6 +29,6 @@ public enum Status {
     }
 
     public static Status mapTo(TestResult result) {
-        return Arrays.stream(values()).filter(item -> item.map.contains(result)).findFirst().orElse(Status.STOPPED);
+        return Arrays.stream(values()).filter(item -> item.map.contains(result)).findFirst().orElse(Status.CANCELLED);
     }
 }

--- a/src/main/java/com/github/invictum/reportportal/SuiteStorage.java
+++ b/src/main/java/com/github/invictum/reportportal/SuiteStorage.java
@@ -52,8 +52,8 @@ public class SuiteStorage {
             SuiteMetadata meta = suites.get(id);
             if (meta.failedTests.isEmpty()) {
                 suites.remove(id);
+                meta.finisher.run();
             }
-            meta.finisher.run();
         });
     }
 

--- a/src/test/java/com/github/invictum/reportportal/UtilsLogLevelTest.java
+++ b/src/test/java/com/github/invictum/reportportal/UtilsLogLevelTest.java
@@ -29,8 +29,9 @@ public class UtilsLogLevelTest {
                 {TestResult.PENDING, LogLevel.DEBUG},
                 {TestResult.SKIPPED, LogLevel.DEBUG},
                 {TestResult.IGNORED, LogLevel.DEBUG},
-                {TestResult.COMPROMISED, LogLevel.WARN},
-                {TestResult.UNDEFINED, LogLevel.FATAL}
+                {TestResult.COMPROMISED, LogLevel.DEBUG},
+                {TestResult.UNDEFINED, LogLevel.FATAL},
+                {TestResult.UNSUCCESSFUL, LogLevel.FATAL}
         };
     }
 }

--- a/src/test/java/com/github/invictum/reportportal/log/unit/AttachmentTest.java
+++ b/src/test/java/com/github/invictum/reportportal/log/unit/AttachmentTest.java
@@ -70,7 +70,7 @@ public class AttachmentTest {
         Assert.assertEquals(1, logs.size());
         SaveLogRQ actual = logs.iterator().next();
         Assert.assertEquals("HTML Source", actual.getMessage());
-        Assert.assertEquals(LogLevel.WARN.toString(), actual.getLevel());
+        Assert.assertEquals(LogLevel.FATAL.toString(), actual.getLevel());
     }
 
     @Test


### PR DESCRIPTION
* Bintray was removed from repositories, because at this moment RP store artifacts in Maven Central. Fore more information, please see: [https://github.com/reportportal/reportportal/issues/1320](https://github.com/reportportal/reportportal/issues/1320)
* Logic of closing suites was fixed. The should be closed after full rerun. We discussed about in one of my previous PR.
* Status binding was changed to don't miss compromised tests in RP. 
