### PR TITLE
Fix bug with compromised tests

### DIFF
--- a/src/main/java/com/github/invictum/reportportal/recorder/Regular.java
+++ b/src/main/java/com/github/invictum/reportportal/recorder/Regular.java
@@ -18,7 +18,7 @@ import java.util.Collection;
  * Common test recorder suitable for most cases
  */
 public class Regular extends TestRecorder {
-    static final int RETRIES_COUNT = ReportIntegrationConfig.get().retriesCount();
+    final int RETRIES_COUNT = ReportIntegrationConfig.get().retriesCount();
 
     @Inject
     public Regular(SuiteStorage suiteStorage, Launch launch, LogUnitsHolder holder) {
@@ -75,7 +75,9 @@ public class Regular extends TestRecorder {
 
     private boolean isTestFailed(TestOutcome out) {
         TestResult testResult = out.getResult();
-        return testResult == TestResult.ERROR || testResult == TestResult.FAILURE;
+        return TestResult.ERROR.equals(testResult) ||
+                TestResult.FAILURE.equals(testResult) ||
+                TestResult.COMPROMISED.equals(testResult);
     }
 
     private void processRetries(TestOutcome out, StartEventBuilder builder) {


### PR DESCRIPTION
We found that compromised tests could be executed by JUnit twice and duplicated in the Report Portal. This fix should help with this.

Before:
![2021-10-21_14-29](https://user-images.githubusercontent.com/5778094/138269091-3b29f303-f42a-4825-bb9a-19df45cdb4df.png)
After:
![2021-10-21_14-28](https://user-images.githubusercontent.com/5778094/138269122-be984c56-7e3c-41d2-9aa7-c924dae3711a.png)
