### PR TITLE
Removed 2 unnecessary stubbings in LogStorageTest.java

### DIFF
--- a/src/test/java/com/github/invictum/reportportal/SecondLogStorageTest.java
+++ b/src/test/java/com/github/invictum/reportportal/SecondLogStorageTest.java
@@ -10,46 +10,39 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.Logs;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
+import org.junit.Rule;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
-public class LogStorageTest {
+public class SecondLogStorageTest {
+
+    @Rule
+    public MockitoRule experimentRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
     private LogStorage storage;
+
     private Logs logsMock;
 
     @Before
     public void beforeTest() {
         storage = new LogStorage();
         logsMock = Mockito.mock(Logs.class);
-        Mockito.when(logsMock.getAvailableLogTypes()).thenReturn(Collections.singleton("data"));
         LogEntry logEntry = new LogEntry(Level.INFO, 42, "Message");
         LogEntry entry = new EnhancedLogEntry("data", logEntry);
         LogEntries entries = new LogEntries(Collections.singleton(entry));
-        Mockito.when(logsMock.get("data")).thenReturn(entries);
     }
 
     @Test
-    public void collectLogsTest() {
-        storage.collect(logsMock);
+    public void queryLogsRemoveTest() {
+        storage.query(item -> true);
         List<EnhancedLogEntry> actual = storage.query(item -> true);
-        Assert.assertEquals(1, actual.size());
-    }
-
-    @Test
-    public void cleanLogsTest() {
-        storage.collect(logsMock);
-        storage.clean();
-        Assert.assertTrue(storage.query(item -> true).isEmpty());
-    }
-
-    @Test
-    public void collectAvailableTypesOnlyOnceTest() {
-        storage.collect(logsMock);
-        storage.collect(logsMock);
-        Mockito.verify(logsMock, Mockito.times(1)).getAvailableLogTypes();
+        Assert.assertTrue(actual.isEmpty());
     }
 }

--- a/src/test/java/com/github/invictum/reportportal/ThirdLogStorageTest.java
+++ b/src/test/java/com/github/invictum/reportportal/ThirdLogStorageTest.java
@@ -10,15 +10,24 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.Logs;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
+import org.junit.Rule;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
-public class LogStorageTest {
+public class ThirdLogStorageTest {
+
+    @Rule
+    public MockitoRule experimentRule = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
     private LogStorage storage;
+
     private Logs logsMock;
 
     @Before
@@ -29,25 +38,18 @@ public class LogStorageTest {
         LogEntry logEntry = new LogEntry(Level.INFO, 42, "Message");
         LogEntry entry = new EnhancedLogEntry("data", logEntry);
         LogEntries entries = new LogEntries(Collections.singleton(entry));
-        Mockito.when(logsMock.get("data")).thenReturn(entries);
     }
 
     @Test
-    public void collectLogsTest() {
+    public void skipCollectionIfNull() {
+        Mockito.doReturn(null).when(logsMock).get("data");
         storage.collect(logsMock);
-        List<EnhancedLogEntry> actual = storage.query(item -> true);
-        Assert.assertEquals(1, actual.size());
-    }
-
-    @Test
-    public void cleanLogsTest() {
-        storage.collect(logsMock);
-        storage.clean();
         Assert.assertTrue(storage.query(item -> true).isEmpty());
     }
 
     @Test
-    public void collectAvailableTypesOnlyOnceTest() {
+    public void disabledOnError() {
+        Mockito.when(logsMock.getAvailableLogTypes()).thenThrow(WebDriverException.class);
         storage.collect(logsMock);
         storage.collect(logsMock);
         Mockito.verify(logsMock, Mockito.times(1)).getAvailableLogTypes();


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 2 unnecessary stubbings which stubbed `getAvailableLogTypes` method, `get` method in `beforeTest` are created but are never executed by 5 tests `LogStorageTest.collectLogsTest`, `LogStorageTest.cleanLogsTest`, `LogStorageTest.collectAvailableTypesOnlyOnceTest`, `LogStorageTest.skipCollectionIfNull`, `LogStorageTest.disabledOnError`. [See `SecondLogStorageTest.java`]

2) 1 unnecessary stubbing which stubbed `get` method in `beforeTest` is created but is never executed by 4 tests `LogStorageTest.collectLogsTest`, `LogStorageTest.cleanLogsTest`, `LogStorageTest.collectAvailableTypesOnlyOnceTest`, `LogStorageTest.queryLogsRemoveTest`. [See`ThirdLogStorageTest.java `]

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.